### PR TITLE
Use ISMISSING  in place of MISSING

### DIFF
--- a/src/morphydefs.h
+++ b/src/morphydefs.h
@@ -28,7 +28,7 @@ typedef double Mflt;
 typedef unsigned int MPLstate;
 
 #define NA              ((MPLstate)0b1)
-#define MISSING         ((MPLstate)~0)
+#define ISMISSING       ((MPLstate)~0)
 #define ISAPPLIC        (((MPLstate)~0)^NA)
 #define MAXSTATES       (CHAR_BIT * sizeof(MPLstate))
 #define DEFAULTGAP      '-'

--- a/src/statedata.c
+++ b/src/statedata.c
@@ -185,14 +185,14 @@ MPLstate mpl_convert_gap_symbol(Morphyp handl, bool over_cutoff)
             return NA;
         }
         else {
-            return MISSING;
+            return ISMISSING;
         }
     }
     else if (handl->gaphandl == GAP_NEWSTATE) {
         return (MPLstate)1;
     }
     else if (handl->gaphandl == GAP_MISSING) {
-        return MISSING;
+        return ISMISSING;
     }
     
     return ERR_NO_DATA;
@@ -254,7 +254,7 @@ int mpl_convert_cells(Morphyp handl)
                 cell->asint = mpl_convert_gap_symbol(handl, over_cutoff);
             }
             else if (*celldata == handl->symbols.missing) {
-                cell->asint = MISSING;
+                cell->asint = ISMISSING;
             }
             else {
                 cell->asint = mpl_convert_char_to_MPLstate(celldata, handl);
@@ -436,7 +436,7 @@ MPLstate mpl_gap_value(Morphyp handl)
         case GAP_INAPPLIC:
             return NA;
         case GAP_MISSING:
-            return MISSING;
+            return ISMISSING;
         case GAP_NEWSTATE:
             return (MPLstate)1;
         case GAP_MAX:
@@ -681,7 +681,7 @@ char *mpl_translate_state2char(MPLstate cstates, Morphyp handl)
     }
     char* symbols = mpl_get_symbols((Morphy)handl);
     
-    if (cstates < (MISSING-NA)) {
+    if (cstates < (ISMISSING-NA)) {
         while (cstates) {
             if (1 & cstates) {
                 if (shift == 0 && gapshift) {


### PR DESCRIPTION
I am encountering a warning when using MorphyLib in R, because R defines a variable `MISSING` in its own header files, so when the morphy library headers are called, `MISSING` is already defined.

An easy way to avoid this conflict would be to rename MISSING to ISMISSING, or perhaps MPLMISSING.