### PR TITLE
Revert "0b1 is not C11 compliant; using octal instead"

### DIFF
--- a/src/morphydefs.h
+++ b/src/morphydefs.h
@@ -27,7 +27,7 @@ typedef double Mflt;
 
 typedef unsigned int MPLstate;
 
-#define NA              ((MPLstate)01) // 0b1 is not C11 compliant; using octal instead
+#define NA              ((MPLstate)0b1)
 #define MISSING         ((MPLstate)~0)
 #define ISAPPLIC        (((MPLstate)~0)^NA)
 #define MAXSTATES       (CHAR_BIT * sizeof(MPLstate))


### PR DESCRIPTION
Reverts mbrazeau/morphylib#17: should be placed on the development branch and then merged to master just to keep life simple.