### PR TITLE
Fix warning: ordered comparison of pointer with integer zero

### DIFF
--- a/src/statedata.c
+++ b/src/statedata.c
@@ -400,7 +400,7 @@ int mpl_check_nexus_matrix_dimensions
             else {
                 err = mpl_skip_closure(current, '{', '}');
             }
-            if (err <= 0) {
+            if (*err <= 0) {
                 return ERR_MATCHING_PARENTHS;
             }
             


### PR DESCRIPTION
Warning generated in https://www.r-project.org/nosvn/R.check/r-devel-windows-ix86+x86_64/TreeSearch-00install.html