### PR TITLE
Fix  warning: redefinition of typedef 'MPLndsets' [-Wpedantic]

### DIFF
--- a/src/morphydefs.h
+++ b/src/morphydefs.h
@@ -46,7 +46,6 @@ typedef unsigned int MPLstate;
 #define MPLWTMIN        (MPL_EPSILON * 10) /*! Safest (for me!) if calculations
                                                steer pretty clear of epsilon */
     
-typedef struct MPLndsets MPLndsets;
 typedef struct partition_s MPLpartition;
 // Evaluator function pointers
 typedef int (*MPLdownfxn)
@@ -82,7 +81,6 @@ typedef struct {
 } MPLcell;
     
 
-typedef struct charinfo_s MPLcharinfo;
 typedef struct charinfo_s {
     
     int         charindex;
@@ -112,7 +110,6 @@ typedef struct {
 } MPLcupdate;
     
     
-typedef struct partition_s MPLpartition;
 typedef struct partition_s {
     
     MPLchtype       chtype;         /*!< The optimality type used for this partition. */


### PR DESCRIPTION
Warning generated in https://www.r-project.org/nosvn/R.check/r-devel-windows-ix86+x86_64/TreeSearch-00install.html
```
morphydefs.h:103:3: warning: redefinition of typedef 'MPLcharinfo' [-Wpedantic]
 } MPLcharinfo;
   ^
morphydefs.h:83:27: note: previous declaration of 'MPLcharinfo' was here
 typedef struct charinfo_s MPLcharinfo;
                           ^
morphydefs.h:113:28: warning: redefinition of typedef 'MPLpartition' [-Wpedantic]
 typedef struct partition_s MPLpartition;
                            ^
morphydefs.h:48:28: note: previous declaration of 'MPLpartition' was here
 typedef struct partition_s MPLpartition;
                            ^
morphydefs.h:148:3: warning: redefinition of typedef 'MPLpartition' [-Wpedantic]
 } MPLpartition;
   ^
morphydefs.h:113:28: note: previous declaration of 'MPLpartition' was here
 typedef struct partition_s MPLpartition;
                            ^
morphydefs.h:172:3: warning: redefinition of typedef 'MPLndsets' [-Wpedantic]
 } MPLndsets;
   ^
```

(I've not tested whether this fixes the error, or indeed whether it works...)