### PR TITLE
Handle `nstates == 0`

### DIFF
--- a/src/statedata.c
+++ b/src/statedata.c
@@ -483,7 +483,7 @@ int mpl_init_inmatrix(Morphyp handl)
     int i = 0;
     
     for (i = 0; i < mat->ncells; ++i) {
-        mat->cells[i].asstr = (char*)calloc(nstates + 1, sizeof(char));
+        mat->cells[i].asstr = (char*)calloc(nstates ? nstates + 1 : 2, sizeof(char));
         if (!mat->cells[i].asstr) {
             int j = 0;
             for (j = 0; j < i; ++j) {


### PR DESCRIPTION
Not sure whether this will be relevant, or whether this repo is still active, but just in case it's useful...

When running some filtered datasets I've encountered the admittedly unusual scenario where `nstates == 0`.

Line 598 requires `.asstr` to contain at least two elements:
```c
            handl->inmatrix.cells[i].asstr[1] = '\0';
```
 Setting a minimum value as proposed in line 486 seems to fix this: at least, valgrind doesn't complain.  I didn't follow the code far enough to look for other side-effects!